### PR TITLE
Allow prometheus client to handle invalid UTF8

### DIFF
--- a/lib/fluent/plugin/monkey_patches/prometheus_client.rb
+++ b/lib/fluent/plugin/monkey_patches/prometheus_client.rb
@@ -1,0 +1,17 @@
+# frozen_string_literals: true
+
+ # Monkey patch escape to handle non-UTF8 strings
+module Prometheus
+  module Client
+    module Formats
+      module Text
+        def self.escape(string, format = :doc)
+          string.
+            to_s.
+            encode("UTF-8", undef: :replace, invalid: :replace).
+            gsub(REGEX[format], REPLACE)
+        end
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -1,6 +1,7 @@
 require 'prometheus/client'
 require 'prometheus/client/formats/text'
 require 'fluent/plugin/filter_record_transformer'
+require 'fluent/plugin/monkey_patches/prometheus_client.rb'
 
 module Fluent
   module Plugin


### PR DESCRIPTION
We have an ongoing issue where invalid UTF8 is being passed to the
prometheus client which blows up preventing us serving metrics. We have
tried to resolve this in fluentd but have been unable to so as a stop gap
(a possibly long one) we are patching the ruby prometheus client to
siliently handle invalid UTF8 and therefore continute to serve metrics.